### PR TITLE
Docker file example

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+#
+# Copyright © 2018 The Thingsboard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM thingsboard/tb-node:3.5.0
+COPY target/rule-engine-1.0.0-custom-nodes.jar /usr/share/thingsboard/extensions/
+
+#USER root
+#
+#RUN apt-get update && apt-get install -y \
+#    htop curl wget net-tools iputils-ping traceroute \
+#    && rm -rf /var/lib/apt/lists/*
+#
+#USER thingsboard

--- a/README.md
+++ b/README.md
@@ -4,3 +4,5 @@ Examples of custom Rule Nodes for ThingsBoard contribution guide
 Unit tests examples for custom rule nodes added as well
 
 To build the project run `mvn clean install`
+
+To build a custom Docker image run `DOCKER_BUILDKIT=0 docker build . -t your_repo/tb-node:3.5.0-custom-1`


### PR DESCRIPTION
Docker file example on how to build a custom `thingsboard/tb-node` image with custom rule nodes installed.