### PR TITLE
updated TbKeyFilterNode to be versioned node && removed destroy method because it is identical to its super method 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <main.dir>${basedir}</main.dir>
-        <thingsboard.version>3.5.0</thingsboard.version>
+        <thingsboard.version>3.5.2-SNAPSHOT</thingsboard.version>
         <lombok.version>1.18.18</lombok.version>
         <guava.version>31.1-jre</guava.version>
         <!--         TEST SCOPE         -->

--- a/src/main/java/org/thingsboard/rule/engine/node/enrichment/TbGetSumIntoMetadata.java
+++ b/src/main/java/org/thingsboard/rule/engine/node/enrichment/TbGetSumIntoMetadata.java
@@ -83,8 +83,4 @@ public class TbGetSumIntoMetadata implements TbNode {
         }
     }
 
-    @Override
-    public void destroy() {
-
-    }
 }

--- a/src/main/java/org/thingsboard/rule/engine/node/filter/FilterSource.java
+++ b/src/main/java/org/thingsboard/rule/engine/node/filter/FilterSource.java
@@ -15,20 +15,9 @@
  */
 package org.thingsboard.rule.engine.node.filter;
 
-import lombok.Data;
-import org.thingsboard.rule.engine.api.NodeConfiguration;
+public enum FilterSource {
 
-@Data
-public class TbKeyFilterNodeConfiguration implements NodeConfiguration<TbKeyFilterNodeConfiguration> {
+    DATA,
+    METADATA
 
-    private String key;
-    private FilterSource filterSource;
-
-    @Override
-    public TbKeyFilterNodeConfiguration defaultConfiguration() {
-        TbKeyFilterNodeConfiguration configuration = new TbKeyFilterNodeConfiguration();
-        configuration.setKey(null);
-        configuration.setFilterSource(FilterSource.DATA);
-        return configuration;
-    }
 }

--- a/src/main/java/org/thingsboard/rule/engine/node/transform/TbCalculateSumNode.java
+++ b/src/main/java/org/thingsboard/rule/engine/node/transform/TbCalculateSumNode.java
@@ -84,7 +84,4 @@ public class TbCalculateSumNode implements TbNode {
         return System.currentTimeMillis();
     }
 
-    @Override
-    public void destroy() {
-    }
 }


### PR DESCRIPTION
The PR status is set to WIP since there is no release branch for v3.5.2 created in the main repo yet. Also, this change should be applied only after the documentation for custom rule nodes will be updated: https://thingsboard.io/docs/user-guide/contribution/rule-node-development/

Hint for docs regarding the upgrade method:

/**
 * Let's imagine that after a while,
 * you will decide to upgrade the rule node configuration again,
 * for example, from version 1 to version  2.
 * In such a case, our suggestion is to replace the if statement
 * with a switch case model that will include a break statement
 * only before the default case.
 * In such way your upgrade script will be valid
 * even if you will decide to perform upgrade from version 0 to version 2.
 */