### PR TITLE
3.6.0 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-FROM thingsboard/tb-node:3.5.0
+FROM thingsboard/tb-node:3.6.0
 COPY target/rule-engine-1.0.0-custom-nodes.jar /usr/share/thingsboard/extensions/
 
 #USER root

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Unit tests examples for custom rule nodes added as well
 
 To build the project run `mvn clean install`
 
-To build a custom Docker image run `DOCKER_BUILDKIT=0 docker build . -t your_repo/tb-node:3.5.0-custom-1`
+To build a custom Docker image run `DOCKER_BUILDKIT=0 docker build . -t your_repo/tb-node:3.6.0-custom-1`

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <main.dir>${basedir}</main.dir>
-        <thingsboard.version>3.5.0</thingsboard.version>
+        <thingsboard.version>3.6.0</thingsboard.version>
         <lombok.version>1.18.18</lombok.version>
         <guava.version>31.1-jre</guava.version>
         <!--         TEST SCOPE         -->

--- a/src/main/java/org/thingsboard/rule/engine/node/enrichment/TbGetSumIntoMetadata.java
+++ b/src/main/java/org/thingsboard/rule/engine/node/enrichment/TbGetSumIntoMetadata.java
@@ -29,7 +29,7 @@ import org.thingsboard.server.common.msg.TbMsg;
 import java.io.IOException;
 import java.util.Iterator;
 
-import static org.thingsboard.rule.engine.api.TbRelationTypes.SUCCESS;
+import static org.thingsboard.server.common.data.msg.TbNodeConnectionType.SUCCESS;
 
 /**
  * Created by mshvayka on 10.08.18.


### PR DESCRIPTION
bump version to 3.6.0
Next steps: 
 - upgrade custom-nodes-config.js
 - publish `release-3.6` to be compatible with the documentation page https://thingsboard.io/docs/user-guide/contribution/rule-node-development/
![image](https://github.com/thingsboard/rule-node-examples/assets/79898499/3619da5b-1e95-4922-af2c-39f4c18543ea)
